### PR TITLE
Add filter key to avoid mixing them

### DIFF
--- a/src/Daterangepicker.php
+++ b/src/Daterangepicker.php
@@ -132,4 +132,14 @@ class Daterangepicker extends Filter
             'maxDate' => $this?->maxDate?->format('Y-m-d'),
         ]);
     }
+
+    /**
+     * Get the key for the filter.
+     *
+     * @return string
+     */
+    public function key()
+    {
+        return $this->column;
+    }
 }


### PR DESCRIPTION
If you define multiple `Daterangepicker` and use withMeta to set their name, they will all get the same name, unless you define a filter key.